### PR TITLE
(stable) Fix an issue where raw diffs that are not attached to revisi…

### DIFF
--- a/src/applications/differential/storage/DifferentialDiff.php
+++ b/src/applications/differential/storage/DifferentialDiff.php
@@ -472,6 +472,11 @@ final class DifferentialDiff
             $this->getRevision(),
             PhabricatorPolicyCapability::CAN_VIEW,
           );
+        } else if ($this->getRepositoryPHID()) {
+          $extended[] = array(
+            $this->getRepositoryPHID(),
+            PhabricatorPolicyCapability::CAN_VIEW,
+          );
         }
         break;
     }


### PR DESCRIPTION
…ons could skip repository policy checks

Summary:
See PHI1697. If a diff is not attached to a revision (for example, if it was created with "arc diff --only"), but is attached to a repository, it is supposed to be visible only to users who can see that repository.

It currently skips this extended policy check and may incorrectly be visible to too many users.

(Once a diff is attached to a revision, this rule is enforced properly via the revision policy.)

Test Plan:
  - Set repository R to be visible only to Alice.
  - As Alice, created a diff from a working copy of repository R with "arc diff --only".
  - As Bailey, viewed the diff.
    - Before: visible diff.
    - After: policy exception (as expected).

Differential Revision: https://secure.phabricator.com/D21103